### PR TITLE
feat: create the add card sceens (main screen,fill info,scan)

### DIFF
--- a/flutter app/lib/main.dart
+++ b/flutter app/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'theme/themes.dart';
 import 'theme/theme_modifier.dart';
 import 'theme/theme_demonstration.dart';
+import 'package:cardly/screens/addcard/addCard.dart';
 
 void main() {
   runApp(
@@ -27,7 +28,7 @@ class CardlyApp extends StatelessWidget {
           theme: AppTheme.lightTheme,
           darkTheme: AppTheme.darkTheme,
           themeMode: themeModifier.themeMode,
-          home: const ThemeDemonstration(),
+          home: const AddCardScreen(),
         );
       },
     );

--- a/flutter app/lib/screens/addcard/ScanCard.dart
+++ b/flutter app/lib/screens/addcard/ScanCard.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:cardly/widgets/navBar.dart';
+import 'package:cardly/theme/spacing.dart';
+import 'package:cardly/theme/typography.dart';
+
+// In this screen I simulate a small scanning process
+class ScanCardScreen extends StatefulWidget {
+  const ScanCardScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ScanCardScreen> createState() => _ScanCardScreenState();
+}
+
+class _ScanCardScreenState extends State<ScanCardScreen> {
+  int _activeNavIndex = 1;
+  bool _isScanning = false;
+
+  void _handleScan() {
+    setState(() {
+      _isScanning = true;
+    });
+
+    Future.delayed(const Duration(seconds: 2), () {
+      if (mounted) {
+        setState(() {
+          _isScanning = false;
+        });
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.close, color: Theme.of(context).colorScheme.onBackground),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Scan Card',
+          style: AppTextStyles.heading3(context),
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              padding: AppSpacing.paddingMd,
+              child: Column(
+                children: [
+                  SizedBox(height: AppSpacing.md),
+
+                  Container(
+                    width: double.infinity,
+                    height: 340,
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.onBackground.withAlpha(230),
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        if (!_isScanning)
+                          Container(
+                            width: 220,
+                            height: 220,
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.surface,
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                            child: Center(
+                              child: Icon(
+                                Icons.qr_code_2,
+                                size: 180,
+                                color: Theme.of(context).colorScheme.onSurface,
+                              ),
+                            ),
+                          ),
+
+                        if (_isScanning)
+                          Container(
+                            width: double.infinity,
+                            height: double.infinity,
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.onBackground.withAlpha(230),
+                              borderRadius: BorderRadius.circular(24),
+                            ),
+                            child: Stack(
+                              alignment: Alignment.center,
+                              children: [
+                                Container(
+                                  width: 220,
+                                  height: 220,
+                                  decoration: BoxDecoration(
+                                    border: Border.all(
+                                      color: Theme.of(context).colorScheme.primary,
+                                      width: 3,
+                                    ),
+                                    borderRadius: BorderRadius.circular(16),
+                                  ),
+                                ),
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(
+                                      Icons.qr_code_scanner,
+                                      size: 80,
+                                      color: Theme.of(context).colorScheme.primary,
+                                    ),
+                                    const SizedBox(height: 16),
+                                    Text(
+                                      'Scanning...',
+                                      style: AppTextStyles.heading3(context).copyWith(
+                                        color: Theme.of(context).colorScheme.onPrimary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+
+                  SizedBox(height: AppSpacing.lg),
+
+                  Text(
+                    'Point your camera at a business card or QR code',
+                    textAlign: TextAlign.center,
+                    style: AppTextStyles.bodySmall(context),
+                  ),
+
+                  SizedBox(height: AppSpacing.xl),
+                ],
+              ),
+            ),
+          ),
+
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: AppSpacing.md, vertical: AppSpacing.sm),
+              child: SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _isScanning ? null : _handleScan,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Container(
+                        width: 24,
+                        height: 24,
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.onPrimary.withOpacity(0.2),
+                          shape: BoxShape.circle,
+                        ),
+                        child: Icon(
+                          Icons.camera_alt,
+                          size: 19,
+                          color: Theme.of(context).colorScheme.onPrimary,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Text(
+                        _isScanning ? 'Scanning...' : 'Scan',
+                        style: AppTextStyles.buttonPrimary(context),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+
+          BottomNavBar(
+            activeIndex: _activeNavIndex,
+            onTabChange: (index) {
+              setState(() {
+                _activeNavIndex = index;
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+

--- a/flutter app/lib/screens/addcard/addCard.dart
+++ b/flutter app/lib/screens/addcard/addCard.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:cardly/widgets/navBar.dart';
+import 'package:cardly/widgets/buildDivider.dart';
+import 'package:cardly/theme/colors.dart';
+import 'package:cardly/theme/spacing.dart';
+import 'package:cardly/theme/typography.dart';
+import 'package:cardly/screens/addcard/fillcardinformations.dart';
+import 'package:cardly/screens/addcard/ScanCard.dart';
+class AddCardScreen extends StatefulWidget {
+  const AddCardScreen({Key? key}) : super(key: key);
+
+  @override
+  State<AddCardScreen> createState() => _AddCardScreenState();
+}
+
+class _AddCardScreenState extends State<AddCardScreen> {
+  final TextEditingController _cardIdController = TextEditingController();
+  int _activeNavIndex = 1;
+
+  @override
+  void dispose() {
+    _cardIdController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        elevation: 0,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        leading: IconButton(
+          icon: Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Add Card',
+          style: AppTextStyles.heading3(context),
+        ),
+      ),
+      body: Column(
+        children: [
+          const SizedBox(height: AppSpacing.lg),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: AppSpacing.paddingMd,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Enter the Card ID',
+                    style: AppTextStyles.heading2(context),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    'If the business card is registered in our app',
+                    style: AppTextStyles.bodySmall(context).copyWith(color: AppColors.primary),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  TextField(
+                    controller: _cardIdController,
+                    decoration: const InputDecoration(
+                      hintText: 'Cardly Card ID',
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: () {},
+                      child: Text(
+                        'Enter',
+                        style: AppTextStyles.buttonPrimary(context),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  buildDivider(context),
+                  const SizedBox(height: AppSpacing.lg),
+                  Text(
+                    'Fill The Card Manually',
+                    style: AppTextStyles.heading3(context),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const Fillcardinformations(),
+                          ),
+                        );
+                      },
+                      child: Text(
+                        'Fill Manually',
+                        style: AppTextStyles.buttonSecondary(context),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  buildDivider(context),
+                  const SizedBox(height: AppSpacing.lg),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      GestureDetector(
+                        onTap: () {},
+                        child: Container(
+                          width: 64,
+                          height: 64,
+                          decoration: BoxDecoration(
+                            color: AppColors.primary,
+                            shape: BoxShape.circle,
+                          ),
+                          child: const Icon(
+                            Icons.image,
+                            color: Colors.white,
+                            size: 28,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.lg),
+                      GestureDetector(
+                        onTap: () {},
+                        child: Container(
+                          width: 64,
+                          height: 64,
+                          decoration: BoxDecoration(
+                            color: AppColors.primary,
+                            shape: BoxShape.circle,
+                          ),
+                          child: const Icon(
+                            Icons.camera_alt,
+                            color: Colors.white,
+                            size: 28,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const ScanCardScreen(),
+                          ),
+                        );
+                      },
+                      icon: const Icon(
+                        Icons.qr_code_scanner,
+                        size: 20,
+                      ),
+                      label: Text(
+                        'Scan QR Code',
+                        style: AppTextStyles.buttonSecondary(context),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                ],
+              ),
+            ),
+          ),
+
+          BottomNavBar(
+            activeIndex: _activeNavIndex,
+            onTabChange: (index) {
+              setState(() {
+                _activeNavIndex = index;
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter app/lib/screens/addcard/addCardinformations.dart
+++ b/flutter app/lib/screens/addcard/addCardinformations.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:cardly/widgets/buildTextField.dart';
+import 'package:cardly/widgets/navBar.dart' ;
+import 'package:cardly/theme/spacing.dart';
+import 'package:cardly/theme/typography.dart';
+class Addcardinformations extends StatefulWidget {
+  const Addcardinformations({Key? key}) : super(key: key);
+
+  @override
+  State<Addcardinformations> createState() => _AddcardinformationsState();
+}
+
+class _AddcardinformationsState extends State<Addcardinformations> {
+  final TextEditingController _fullNameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _phoneController = TextEditingController();
+  final TextEditingController _companyController = TextEditingController();
+  final TextEditingController _jobTitleController = TextEditingController();
+  final TextEditingController _locationController = TextEditingController();
+  final TextEditingController _websiteController = TextEditingController();
+  final TextEditingController _aboutController = TextEditingController();
+  
+  int _activeNavIndex = 1;
+
+  @override
+  void dispose() {
+    _fullNameController.dispose();
+    _emailController.dispose();
+    _phoneController.dispose();
+    _companyController.dispose();
+    _jobTitleController.dispose();
+    _locationController.dispose();
+    _websiteController.dispose();
+    _aboutController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.close, color: Colors.black),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Add Card',
+          style: AppTextStyles.heading3(context),
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              padding: AppSpacing.paddingLg,
+              child: Column(
+                children: [
+                  buildTextField(context, 'Full Name', _fullNameController),
+                  buildTextField(context, 'Email', _emailController),
+                  buildTextField(context, 'Phone', _phoneController),
+                  buildTextField(context, 'Company', _companyController),
+                  buildTextField(context, 'Job Title', _jobTitleController),
+                  buildTextField(context, 'Location', _locationController),
+                  buildTextField(context, 'Website', _websiteController),
+                  buildTextField(context, 'About', _aboutController),
+                  const SizedBox(height: 24),
+                  
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: (){},
+                      child: Text(
+                        'Preview Card',
+                        style: AppTextStyles.buttonPrimary(context),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          BottomNavBar(
+            activeIndex: _activeNavIndex,
+            onTabChange: (index) {
+              setState(() {
+                _activeNavIndex = index;
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter app/lib/screens/addcard/fillcardinformations.dart
+++ b/flutter app/lib/screens/addcard/fillcardinformations.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:cardly/widgets/buildTextField.dart';
+import 'package:cardly/widgets/navBar.dart' ;
+import 'package:cardly/theme/spacing.dart';
+import 'package:cardly/theme/typography.dart';
+class Fillcardinformations extends StatefulWidget {
+  const Fillcardinformations({Key? key}) : super(key: key);
+
+  @override
+  State<Fillcardinformations> createState() => _FillcardinformationsState();
+}
+
+class _FillcardinformationsState extends State<Fillcardinformations> {
+  final TextEditingController _fullNameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _phoneController = TextEditingController();
+  final TextEditingController _companyController = TextEditingController();
+  final TextEditingController _jobTitleController = TextEditingController();
+  final TextEditingController _locationController = TextEditingController();
+  final TextEditingController _websiteController = TextEditingController();
+  final TextEditingController _aboutController = TextEditingController();
+  
+  int _activeNavIndex = 1;
+
+  @override
+  void dispose() {
+    _fullNameController.dispose();
+    _emailController.dispose();
+    _phoneController.dispose();
+    _companyController.dispose();
+    _jobTitleController.dispose();
+    _locationController.dispose();
+    _websiteController.dispose();
+    _aboutController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.close, color: Colors.black),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Fill Card Informations',
+          style: AppTextStyles.heading3(context),
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              padding: AppSpacing.paddingLg,
+              child: Column(
+                children: [
+                  buildTextField(context, 'Full Name', _fullNameController),
+                  buildTextField(context, 'Email', _emailController),
+                  buildTextField(context, 'Phone', _phoneController),
+                  buildTextField(context, 'Company', _companyController),
+                  buildTextField(context, 'Job Title', _jobTitleController),
+                  buildTextField(context, 'Location', _locationController),
+                  buildTextField(context, 'Website', _websiteController),
+                  buildTextField(context, 'About', _aboutController),
+                  const SizedBox(height: 24),
+                  
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: (){},
+                      child: Text(
+                        'Preview Card',
+                        style: AppTextStyles.buttonPrimary(context),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          BottomNavBar(
+            activeIndex: _activeNavIndex,
+            onTabChange: (index) {
+              setState(() {
+                _activeNavIndex = index;
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter app/lib/widgets/buildDivider.dart
+++ b/flutter app/lib/widgets/buildDivider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:cardly/theme/spacing.dart';
+import 'package:cardly/theme/typography.dart';
+
+Widget buildDivider(BuildContext context) {
+  final color = Theme.of(context).colorScheme.onBackground;
+  return Row(
+    children: [
+      Expanded(child: Container(height: 1, color: Colors.black)),
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+        child: Text(
+          'OR',
+          style: AppTextStyles.heading3(context).copyWith(fontSize: 16, color: color),
+        ),
+      ),
+      Expanded(child: Container(height: 1, color: Colors.black)),
+    ],
+  );
+}

--- a/flutter app/lib/widgets/buildTextField.dart
+++ b/flutter app/lib/widgets/buildTextField.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:cardly/theme/spacing.dart';
+import 'package:cardly/theme/typography.dart';
+
+Widget buildTextField(BuildContext context, String hint, TextEditingController controller) {
+  final bg = Theme.of(context).colorScheme.surface;
+  final textColor = Theme.of(context).colorScheme.onSurface;
+
+  return Container(
+    margin: EdgeInsets.only(bottom: AppSpacing.sm),
+    decoration: BoxDecoration(
+      color: bg,
+      borderRadius: BorderRadius.circular(12),
+    ),
+    child: TextField(
+      controller: controller,
+      style: AppTextStyles.body(context).copyWith(color: textColor),
+      decoration: InputDecoration(
+        hintText: hint,
+        hintStyle: AppTextStyles.bodySmall(context).copyWith(color: textColor.withAlpha(160)),
+        border: InputBorder.none,
+        contentPadding: EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.md,
+        ),
+      ),
+    ),
+  );
+}

--- a/flutter app/lib/widgets/navBar.dart
+++ b/flutter app/lib/widgets/navBar.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class BottomNavBar extends StatelessWidget {
+  Widget _buildNavItem(IconData icon, int index) {
+    final isActive = activeIndex == index;
+    return GestureDetector(
+      onTap: () => onTabChange(index),
+      child: Container(
+        width: 56,
+        height: 56,
+        decoration: BoxDecoration(
+          color: isActive ? const Color(0xFF5B5FEF) : const Color(0xF6F7F8FF),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Icon(
+          icon,
+          color: isActive ? Colors.white : const Color(0xFF5B5FEF),
+          size: 28,
+        ),
+      ),
+    );
+  }
+
+  
+  final int activeIndex;
+  final Function(int) onTabChange;
+  const BottomNavBar({
+    Key? key,
+    this.activeIndex = 1,
+    required this.onTabChange,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
+      child: SafeArea(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            _buildNavItem(Icons.home_filled, 0),
+            _buildNavItem(Icons.add, 1),
+            _buildNavItem(Icons.person, 2),
+          ],
+        ),
+      ),
+    );
+  }
+
+  
+}


### PR DESCRIPTION
Add foor new screens for card management with multiple methods to add business cards.

1. Add Card Screen : Card ID entry for registered cards - Manual entry option - QR code and image scanning buttons
2. Fill Card Information Screen : form
3.Scan Card Screen
4 .add card info
NB: A reusable navBar widget has been implemented and is available for use across all screens ( needs some improvment )